### PR TITLE
Use currentWorkingDirectory instead of temp

### DIFF
--- a/src/main/scala/demo/DemoApp.scala
+++ b/src/main/scala/demo/DemoApp.scala
@@ -6,6 +6,6 @@ object DemoApp extends App {
 
     import FileConverter._
 
-    convert(File.temp / "demofile", File.temp / "result")
+    convert(File.currentWorkingDirectory / "demofile", File.currentWorkingDirectory / "result")
 
 }


### PR DESCRIPTION
Hello, thanks so much for this great tutorial on the IO Monad!
I ran into one annoying challenge when running it, namely that `File.temp` on OS X creates a random directory such as `/var/folders/mj/2nkpw7cd1qd6f38tl1m38f9m0000gp/T/demofile`, making it difficult to use the program. I suggest that you change `temp` to `currentWorkingDirectory` instead, making it easier to predict the location of the input file.